### PR TITLE
Update stack start/stop endpoint query

### DIFF
--- a/Harbour/Stores/PortainerStore/PortainerStore.swift
+++ b/Harbour/Stores/PortainerStore/PortainerStore.swift
@@ -369,7 +369,8 @@ extension PortainerStore {
 	func setStackStatus(stackID: Stack.ID, started: Bool) async throws -> Stack {
 		logger.notice("\(started ? "Starting" : "Stopping", privacy: .public) stack with ID: \(stackID)... [\(String._debugInfo(), privacy: .public)]")
 		do {
-			let stack = try await portainer.setStackStatus(stackID: stackID, started: started)
+			let (portainer, endpoint) = try getPortainerAndEndpoint()
+			let stack = try await portainer.setStackStatus(endpointID: endpoint.id, stackID: stackID, started: started)
 			logger.debug("\(started ? "Started" : "Stopped", privacy: .public) stack with ID: \(stackID) [\(String._debugInfo(), privacy: .public)]")
 			return stack
 		} catch {

--- a/Modules/PortainerKit/Sources/PortainerKit/Portainer/Portainer+Stacks.swift
+++ b/Modules/PortainerKit/Sources/PortainerKit/Portainer/Portainer+Stacks.swift
@@ -21,11 +21,12 @@ public extension Portainer {
 	@Sendable
 	/// Starts a stopped Stack or stops a stopped Stack.
 	/// - Parameters:
+	///   - endpointID: Endpoint identifier
 	///   - stackID: Stack identifier
 	///   - started: Should stack be started?
 	/// - Returns: Affected `Stack`
-	func setStackStatus(stackID: Stack.ID, started: Bool) async throws -> Stack {
-		var request = try request(for: .stackStatus(stackID: stackID, started: started))
+	func setStackStatus(endpointID: Endpoint.ID, stackID: Stack.ID, started: Bool) async throws -> Stack {
+		var request = try request(for: .stackStatus(stackID: stackID, started: started), query: [URLQueryItem(name: "endpointId", value: "\(endpointID)")])
 		request.httpMethod = "POST"
 		return try await fetch(request: request)
 	}


### PR DESCRIPTION
Portainer version 2.19 updated the [endpoint to start or stop](https://app.swaggerhub.com/apis/portainer/portainer-ce/2.19.0#/stacks/StackStart) a stack. There's a new `endpointId` query parameter that is required for the request now. This PR addresses that.